### PR TITLE
Adds init container to increase fs.inotify.max_user_instances

### DIFF
--- a/ch03/lab/deployments.yaml
+++ b/ch03/lab/deployments.yaml
@@ -13,6 +13,17 @@ spec:
         app: lab-numbers-api
         version: v1
     spec:
+      initContainers:
+        # The app requires more than the common Linux default of 128
+        - name: configure-sysctl
+          image: alpine
+          command:
+            - sysctl
+            - '-w'
+            - fs.inotify.max_user_instances=8192
+          securityContext:
+            privileged: true
+            runAsUser: 0
       containers:
         - name: api
           image: kiamol/ch03-numbers-api
@@ -32,6 +43,17 @@ spec:
         app: lab-numbers-web
         version: v1
     spec:
+      initContainers:
+        # The app requires more than the common Linux default of 128
+        - name: configure-sysctl
+          image: alpine
+          command:
+            - sysctl
+            - '-w'
+            - fs.inotify.max_user_instances=8192
+          securityContext:
+            privileged: true
+            runAsUser: 0
       containers:
         - name: web
           image: kiamol/ch03-numbers-web
@@ -51,6 +73,17 @@ spec:
         app: lab-numbers-web
         version: v2
     spec:
+      initContainers:
+        # The app requires more than the common Linux default of 128
+        - name: configure-sysctl
+          image: alpine
+          command:
+            - sysctl
+            - '-w'
+            - fs.inotify.max_user_instances=8192
+          securityContext:
+            privileged: true
+            runAsUser: 0
       containers:
         - name: web
           image: kiamol/ch03-numbers-web:v2

--- a/ch03/numbers/api.yaml
+++ b/ch03/numbers/api.yaml
@@ -11,6 +11,17 @@ spec:
       labels:
         app: numbers-api
     spec:
+      initContainers:
+        # The app requires more than the common Linux default of 128
+        - name: configure-sysctl
+          image: alpine
+          command:
+            - sysctl
+            - '-w'
+            - fs.inotify.max_user_instances=8192
+          securityContext:
+            privileged: true
+            runAsUser: 0
       containers:
         - name: api
           image: kiamol/ch03-numbers-api

--- a/ch03/numbers/web.yaml
+++ b/ch03/numbers/web.yaml
@@ -11,6 +11,17 @@ spec:
       labels:
         app: numbers-web
     spec:
+      initContainers:
+        # The app requires more than the common Linux default of 128
+        - name: configure-sysctl
+          image: alpine
+          command:
+            - sysctl
+            - '-w'
+            - fs.inotify.max_user_instances=8192
+          securityContext:
+            privileged: true
+            runAsUser: 0
       containers:
         - name: web
           image: kiamol/ch03-numbers-web


### PR DESCRIPTION
While having my third lunch I recognized that the web and api examples will fail on some kuberneteses (kubernetis?) with pod error logs like

```
Unhandled exception. System.IO.IOException: The configured user limit (128) on the number of inotify instances has been reached, or the per-process limit on the number of open file descriptors has been reached.
   at System.IO.FileSystemWatcher.StartRaisingEvents()
   blablablalotsmoreofuselessgibberish
```

I created you a PR to add some init containers to increase the kernel parameters a bit. It might interfere with the red line you draw (seems to be a topic for lunch 7) but at the same time might bring the student closer to the brutal truth of the "write once, run anywhere" reality ;)
