### PR TITLE
solution (basically same as the given solution)

### DIFF
--- a/ch03/lab/services.yaml
+++ b/ch03/lab/services.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata: 
+  name: numbers-api 
+spec: 
+  selector: 
+    app: lab-numbers-api
+    version: v1
+  ports: 
+    - port: 80
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata: 
+  name: numbers-web 
+spec: 
+  selector: 
+    app: lab-numbers-web
+    version: v2
+  ports: 
+    - port: 8088
+      targetPort: 80
+  type: LoadBalancer
+


### PR DESCRIPTION
Notes from this lab: 
* initially had the app label wrong for the second service, was trying to access lab-numbers-api instead of lab-numbers-web. Lesson learned - read over the yaml file carefully before trying to run it
* not sure when we use LoadBalancer vs ClusterIP - is this because we're hitting the web app from the frontend and the api only through the web app? 