### PR TITLE
Fix 500 server error due to InvalidCastException: Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone', only UTC is supported

### DIFF
--- a/ch04/docker-images/todo-list/src/Startup.cs
+++ b/ch04/docker-images/todo-list/src/Startup.cs
@@ -46,6 +46,7 @@ namespace ToDoList
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
+            AppContext.SetSwitch("Npgsql.EnableLegacyTimestampBehavior", true);
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();


### PR DESCRIPTION
FIX for unhandled exception when adding new items to postgres, due to datetime incompatibilty

An unhandled exception occurred while processing the request.
InvalidCastException: Cannot write DateTime with Kind=Local to PostgreSQL type 'timestamp with time zone', only UTC is supported. Note that it's not possible to mix DateTimes with different Kinds in an array/range. See the Npgsql.EnableLegacyTimestampBehavior AppContext switch to enable legacy behavior.
Npgsql.Internal.TypeHandlers.DateTimeHandlers.TimestampTzHandler.ValidateAndGetLength(DateTime value, NpgsqlParameter parameter)

