### PR TITLE
Fix: Update RBAC API version from v1beta1 to v1

### DIFF
--- a/ch11/infrastructure/jenkins.yaml
+++ b/ch11/infrastructure/jenkins.yaml
@@ -78,7 +78,7 @@ rules:
   resources: ["deployments"]
   verbs: ["get","list","create","delete"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: jenkins

--- a/ch13/fluentbit/fluentbit.yaml
+++ b/ch13/fluentbit/fluentbit.yaml
@@ -59,7 +59,7 @@ rules:
   - pods
   verbs: ["get", "list", "watch"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: fluent-bit

--- a/ch14/lab/monitoring/prometheus.yaml
+++ b/ch14/lab/monitoring/prometheus.yaml
@@ -36,7 +36,7 @@ metadata:
   name: prometheus
   namespace: kiamol-ch14-lab-monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -55,7 +55,7 @@ rules:
   - configmaps
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/ch14/prometheus/prometheus.yaml
+++ b/ch14/prometheus/prometheus.yaml
@@ -36,7 +36,7 @@ metadata:
   name: prometheus
   namespace: kiamol-ch14-monitoring
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus
@@ -55,7 +55,7 @@ rules:
   - configmaps
   verbs: ["get"]
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: prometheus

--- a/ch15/ingress-traefik/traefik-ingress-controller.yaml
+++ b/ch15/ingress-traefik/traefik-ingress-controller.yaml
@@ -70,7 +70,7 @@ metadata:
   namespace: kiamol-ingress-traefik
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ingress-traefik-controller
   namespace: kiamol-ingress-traefik
@@ -101,7 +101,7 @@ rules:
     - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: ingress-traefik-controller
   namespace: kiamol-ingress-traefik

--- a/ch18/setup/flannel.yaml
+++ b/ch18/setup/flannel.yaml
@@ -49,7 +49,7 @@ spec:
     rule: 'RunAsAny'
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 rules:
@@ -78,7 +78,7 @@ rules:
       - patch
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
 roleRef:

--- a/ch21/kubeless/kubeless-v1.0.7.yaml
+++ b/ch21/kubeless/kubeless-v1.0.7.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     kiamol: ch21
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: kubeless-controller-deployer
@@ -111,7 +111,7 @@ rules:
   - update
   - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: kubeless-controller-deployer

--- a/ch21/kubeless/nats-trigger/nats-v1.0.0.yaml
+++ b/ch21/kubeless/nats-trigger/nats-v1.0.0.yaml
@@ -30,7 +30,7 @@ spec:
         name: nats-trigger-controller
       serviceAccountName: controller-acct
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: nats-controller-deployer
@@ -55,7 +55,7 @@ rules:
   - update
   - delete
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: nats-controller-deployer

--- a/ch21/lab/knative/03-contour.yaml
+++ b/ch21/lab/knative/03-contour.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-external
@@ -1375,7 +1375,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: contour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -1391,7 +1391,7 @@ subjects:
   name: contour-certgen
   namespace: contour-external
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen
@@ -1455,7 +1455,7 @@ spec:
   completions: 1
   backoffLimit: 1
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: contour
@@ -1534,7 +1534,7 @@ rules:
   - post
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-leaderelection
@@ -1561,7 +1561,7 @@ rules:
   - update
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour-leaderelection
@@ -1871,7 +1871,7 @@ spec:
       restartPolicy: Always
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: contour-internal
@@ -3248,7 +3248,7 @@ metadata:
   labels:
     networking.knative.dev/ingress-provider: contour
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour
@@ -3264,7 +3264,7 @@ subjects:
   name: contour-certgen
   namespace: contour-internal
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-certgen
@@ -3328,7 +3328,7 @@ spec:
   completions: 1
   backoffLimit: 1
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: contour
@@ -3407,7 +3407,7 @@ rules:
   - post
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: contour-leaderelection
@@ -3434,7 +3434,7 @@ rules:
   - update
   - patch
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: contour-leaderelection


### PR DESCRIPTION
**Description:**

This PR updates the RBAC API version from v1beta1 to v1, aligning with Kubernetes v1.22 deprecation. It ensures compatibility with future Kubernetes updates.

**Changes:**

Updated RBAC API version in affected resources (ClusterRole, ClusterRoleBinding, Role, RoleBinding).